### PR TITLE
fix: handle INA226 address fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Notes
 - Default target MCU is `CH32V003` (see `firmware/Makefile`).
 - Export `MINICHLINK` if using a custom minichlink binary location.
 
+### Display Orientation
+
+- The OLED can be shown in normal orientation (default) or rotated 180°.
+- Configure at build time via `DISPLAY_ORIENTATION_180`:
+
+  - Edit `firmware/funconfig.h` and set `#define DISPLAY_ORIENTATION_180 1`, or
+  - Recommended: pass `EXTRA_CFLAGS+=-DDISPLAY_ORIENTATION_180=1` to avoid overriding internal `CFLAGS`.
+    For example: `make flash EXTRA_CFLAGS+=-DDISPLAY_ORIENTATION_180=1` (at repo root), or append it in `firmware/Makefile`.
+
+Under the hood the firmware rotates the framebuffer in software at flush time (page+bit+column reversal), so drawing APIs stay the same.
+
 ## License
 
 The Whisker Breeze sources are provided under the MIT license. The `ch32fun`

--- a/firmware/funconfig.h
+++ b/firmware/funconfig.h
@@ -14,4 +14,21 @@
 
 /* No extra biases are needed with software rotation. */
 
+/* INA226 I2C address selector
+ * 0 = ADR strapped low  -> 0x40 (default)
+ * 1 = ADR strapped high -> 0x44
+ * You may override via compiler flag: -DINA226_ADDR_SELECT_0X44=1 or -DINA226_I2C_ADDR=0x44
+ */
+#ifndef INA226_ADDR_SELECT_0X44
+#define INA226_ADDR_SELECT_0X44 0
+#endif
+
+#ifndef INA226_I2C_ADDR
+#if INA226_ADDR_SELECT_0X44
+#define INA226_I2C_ADDR 0x44u
+#else
+#define INA226_I2C_ADDR 0x40u
+#endif
+#endif
+
 #endif

--- a/firmware/funconfig.h
+++ b/firmware/funconfig.h
@@ -3,4 +3,15 @@
 
 #define FUNCONF_USE_DEBUGPRINTF 1
 
+/* Display orientation config
+ * 0 = normal (default)
+ * 1 = rotate 180 degrees
+ * You may override via compiler flag: -DDISPLAY_ORIENTATION_180=1
+ */
+#ifndef DISPLAY_ORIENTATION_180
+#define DISPLAY_ORIENTATION_180 0
+#endif
+
+/* No extra biases are needed with software rotation. */
+
 #endif


### PR DESCRIPTION
## Summary
- add INA226 address selector to `funconfig.h`
- add runtime fallback to probe both INA226 addresses before panicking

## Testing
- make -C firmware
- make -C firmware EXTRA_CFLAGS='-DINA226_ADDR_SELECT_0X44=1'
