### PR TITLE
feat(oled): render 8x8 font from external EEPROM; add font-writer and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
-.PHONY: all flash clean attach
+.PHONY: all flash flash-font clean attach
 
-all: flash
+all:
+	$(MAKE) -C firmware all
 
 flash:
 	$(MAKE) -C firmware flash
+
+flash-font:
+	$(MAKE) -C firmware flash-eeprom_font_writer
 
 clean:
 	$(MAKE) -C firmware clean

--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ Prerequisites
 Build & Flash (from repository root)
 
 ```sh
-make        # rebuilds firmware and flashes (proxy to firmware/)
+make flash           # rebuilds and flashes the main controller firmware
+make flash-font      # flash EEPROM font writer, programs glyphs, then reflash main
 ```
 
 Useful targets
 
 - `make flash` - forces rebuild then programs the board via minichlink.
+- `make flash-font` - flashes the `eeprom_font_writer` utility; it writes and verifies the 2 kB font blob at EEPROM offsets `0x0200–0x09FF` before idling. Reflash the main firmware afterwards.
 - `make clean` - removes build artefacts in `firmware/`.
 - `make attach` - opens a persistent minichlink debug session.
 
@@ -61,6 +63,7 @@ Notes
 
 - Default target MCU is `CH32V003` (see `firmware/Makefile`).
 - Export `MINICHLINK` if using a custom minichlink binary location.
+- The 8×8 monospace font previously linked into flash now lives inside the external EEPROM (2 kB region starting at `0x0200`). Ensure the writer firmware has been run at least once after assembling or replacing the EEPROM.
 
 ### Power Behavior
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -62,6 +62,8 @@ Power sequencing must follow §4.2 of the datasheet: VDD first, then issue `DISP
 - **Power**: Pin 8 connected to `3V3`; `VSS` (pin 4) to ground. A 100 nF bypass capacitor (C18) is placed adjacent to the package between `VCC` and `GND`.
 - **Bus Topology**: Shares the main 3V3 I²C bus (`SDA` on PC1, `SCL` on PC2) with the SSD1306 display and INA226 current monitor; 4.7 kΩ pull-ups already present on the bus.
 - **Memory Organisation**: 8 kB array organised as 32-byte pages; sequential writes wrap within the current page. Firmware keeps the configuration record in the first page and ensures updates stay inside a single page boundary to avoid wraparound side-effects.
+- **Font Store**: Bytes `0x0200–0x09FF` (2 kB) persist the 8×8 ASCII glyph table previously linked into flash. The production firmware streams glyph rows from this region at render time instead of carrying the table in program memory.
+- **Provisioning**: A dedicated `eeprom_font_writer` firmware image performs a full erase/program/verify pass of the 2 kB font payload. Run it after EEPROM replacement or when updating the font table.
 - **Write Cycle**: Typical internal write time 5 ms (10 ms max). Firmware performs ACK polling after every STOP condition and clears `AF` error flags between attempts so the controller never stalls while the EEPROM finalises its write cycle.
 - **Purpose**: Persists user mode selections across power cycles—specifically whether the controller last ran in automatic (temperature) or manual mode and the manual fan speed target. Firmware writes a compact record after user changes and reapplies it once tach calibration completes at the next boot.
 

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,14 +1,43 @@
-.PHONY: all flash clean attach
+TARGETS := whisker_breeze eeprom_font_writer
+MINICHLINK ?= ../ch32fun/minichlink
 
-TARGET:=whisker_breeze
-TARGET_MCU?=CH32V003
-TARGET_EXT?=c
+.PHONY: all flash clean attach flash-whisker_breeze flash-eeprom_font_writer
 
-include ../ch32fun/ch32fun/ch32fun.mk
+ifeq ($(TARGET),)
 
-all: flash
-flash: cv_flash
-clean: cv_clean
+all:
+	@for t in $(TARGETS); do \
+		$(MAKE) TARGET=$$t build; \
+	done
+
+flash: flash-whisker_breeze
+
+flash-whisker_breeze:
+	$(MAKE) TARGET=whisker_breeze flash
+
+flash-eeprom_font_writer:
+	$(MAKE) TARGET=eeprom_font_writer flash
+
+clean:
+	@for t in $(TARGETS); do \
+		$(MAKE) TARGET=$$t cv_clean; \
+	done
 
 attach:
 	$(MINICHLINK)/minichlink -T
+
+else
+
+TARGET_MCU?=CH32V003
+TARGET_EXT?=c
+ADDITIONAL_C_FILES:=i2c_lowlevel.c eeprom_font_storage.c
+
+include ../ch32fun/ch32fun/ch32fun.mk
+
+all: build
+
+flash: cv_flash
+
+clean: cv_clean
+
+endif

--- a/firmware/eeprom_font_storage.c
+++ b/firmware/eeprom_font_storage.c
@@ -1,0 +1,285 @@
+#include "eeprom_font_storage.h"
+
+#include <string.h>
+
+#include "ch32fun.h"
+#include "i2c_lowlevel.h"
+
+#define EEPROM_I2C_ADDR 0x50u
+
+static void eeprom_clear_ack_failure(void)
+{
+    if (I2C1->STAR1 & I2C_STAR1_AF) {
+        I2C1->STAR1 &= (uint16_t)~I2C_STAR1_AF;
+    }
+}
+
+static void eeprom_issue_stop(void)
+{
+    I2C1->CTLR1 |= I2C_CTLR1_STOP;
+}
+
+static bool eeprom_read_byte(uint16_t offset, uint8_t *value)
+{
+    if (!value) {
+        return false;
+    }
+    if (offset >= EEPROM_TOTAL_SIZE_BYTES) {
+        return false;
+    }
+
+    if (!i2c1_wait_not_busy()) {
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_START;
+    if (!i2c1_wait_flag(0x00030001u)) {
+        eeprom_issue_stop();
+        return false;
+    }
+
+    I2C1->DATAR = (uint16_t)((uint16_t)EEPROM_I2C_ADDR << 1);
+    if (!i2c1_wait_flag(0x00070082u)) {
+        eeprom_clear_ack_failure();
+        eeprom_issue_stop();
+        return false;
+    }
+
+    int32_t timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        eeprom_issue_stop();
+        return false;
+    }
+
+    I2C1->DATAR = (uint8_t)(offset >> 8);
+    if (!i2c1_wait_flag(0x00070084u)) {
+        eeprom_issue_stop();
+        return false;
+    }
+
+    timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        eeprom_issue_stop();
+        return false;
+    }
+
+    I2C1->DATAR = (uint8_t)(offset & 0xFFu);
+    if (!i2c1_wait_flag(0x00070084u)) {
+        eeprom_issue_stop();
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_START;
+    if (!i2c1_wait_flag(0x00030001u)) {
+        eeprom_issue_stop();
+        return false;
+    }
+
+    I2C1->DATAR = (uint16_t)(((uint16_t)EEPROM_I2C_ADDR << 1) | 1u);
+    if (!i2c1_wait_flag(0x00030002u)) {
+        eeprom_clear_ack_failure();
+        eeprom_issue_stop();
+        return false;
+    }
+
+    I2C1->CTLR1 &= ~I2C_CTLR1_ACK;
+    I2C1->CTLR1 |= I2C_CTLR1_STOP;
+
+    timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_RXNE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        I2C1->CTLR1 |= I2C_CTLR1_ACK;
+        return false;
+    }
+
+    *value = (uint8_t)I2C1->DATAR;
+    I2C1->CTLR1 |= I2C_CTLR1_ACK;
+    return true;
+}
+
+static bool eeprom_write_page(uint16_t offset, const uint8_t *data, uint16_t length)
+{
+    if (!data || length == 0u) {
+        return false;
+    }
+    if (!i2c1_wait_not_busy()) {
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_START;
+    if (!i2c1_wait_flag(0x00030001u)) {
+        eeprom_issue_stop();
+        return false;
+    }
+
+    I2C1->DATAR = (uint16_t)((uint16_t)EEPROM_I2C_ADDR << 1);
+    if (!i2c1_wait_flag(0x00070082u)) {
+        eeprom_clear_ack_failure();
+        eeprom_issue_stop();
+        return false;
+    }
+
+    int32_t timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        eeprom_issue_stop();
+        return false;
+    }
+
+    I2C1->DATAR = (uint8_t)(offset >> 8);
+    if (!i2c1_wait_flag(0x00070084u)) {
+        eeprom_issue_stop();
+        return false;
+    }
+
+    timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        eeprom_issue_stop();
+        return false;
+    }
+
+    I2C1->DATAR = (uint8_t)(offset & 0xFFu);
+    if (!i2c1_wait_flag(0x00070084u)) {
+        eeprom_issue_stop();
+        return false;
+    }
+
+    for (uint16_t idx = 0; idx < length; ++idx) {
+        timeout = 100000;
+        while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
+        }
+        if (timeout <= 0) {
+            eeprom_issue_stop();
+            return false;
+        }
+
+        I2C1->DATAR = data[idx];
+        if (!i2c1_wait_flag(0x00070084u)) {
+            eeprom_issue_stop();
+            return false;
+        }
+    }
+
+    eeprom_issue_stop();
+    return true;
+}
+
+bool eeprom_read_bytes(uint16_t offset, uint8_t *data, uint16_t length)
+{
+    if (!data || length == 0u) {
+        return false;
+    }
+    uint32_t end = (uint32_t)offset + (uint32_t)length;
+    if (end > EEPROM_TOTAL_SIZE_BYTES) {
+        return false;
+    }
+
+    for (uint16_t idx = 0; idx < length; ++idx) {
+        if (!eeprom_read_byte((uint16_t)(offset + idx), &data[idx])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool eeprom_write_bytes(uint16_t offset, const uint8_t *data, uint16_t length)
+{
+    if (!data || length == 0u) {
+        return false;
+    }
+    uint32_t end = (uint32_t)offset + (uint32_t)length;
+    if (end > EEPROM_TOTAL_SIZE_BYTES) {
+        return false;
+    }
+
+    uint16_t remaining = length;
+    uint16_t current_offset = offset;
+    const uint8_t *current = data;
+
+    while (remaining > 0u) {
+        uint16_t page_space = EEPROM_PAGE_SIZE_BYTES - (current_offset % EEPROM_PAGE_SIZE_BYTES);
+        uint16_t chunk = (remaining < page_space) ? remaining : page_space;
+
+        if (!eeprom_write_page(current_offset, current, chunk)) {
+            return false;
+        }
+        if (!eeprom_wait_ready(20u)) {
+            return false;
+        }
+
+        current_offset = (uint16_t)(current_offset + chunk);
+        current += chunk;
+        remaining = (uint16_t)(remaining - chunk);
+    }
+
+    return true;
+}
+
+bool eeprom_wait_ready(uint32_t timeout_ms)
+{
+    uint32_t attempts = (timeout_ms == 0u) ? 1u : timeout_ms;
+
+    while (attempts-- > 0u) {
+        if (!i2c1_wait_not_busy()) {
+            continue;
+        }
+
+        I2C1->CTLR1 |= I2C_CTLR1_START;
+        if (!i2c1_wait_flag(0x00030001u)) {
+            eeprom_issue_stop();
+            continue;
+        }
+
+        I2C1->DATAR = (uint16_t)((uint16_t)EEPROM_I2C_ADDR << 1);
+        if (i2c1_wait_flag(0x00030002u)) {
+            (void)I2C1->STAR1;
+            (void)I2C1->STAR2;
+            eeprom_issue_stop();
+            return true;
+        }
+
+        eeprom_clear_ack_failure();
+        eeprom_issue_stop();
+        Delay_Ms(1u);
+    }
+
+    return false;
+}
+
+bool font_storage_fetch_rows(uint8_t code, uint8_t *rows)
+{
+    if (!rows) {
+        return false;
+    }
+
+    uint32_t start = EEPROM_FONT_BASE + ((uint32_t)code << 3);
+    if ((start + 8u) > EEPROM_TOTAL_SIZE_BYTES) {
+        memset(rows, 0, 8u);
+        return false;
+    }
+
+    if (!eeprom_read_bytes((uint16_t)start, rows, 8u)) {
+        memset(rows, 0, 8u);
+        return false;
+    }
+
+    return true;
+}
+
+void ssd1306_font_fetch(uint8_t chr, uint8_t *rows)
+{
+    if (!rows) {
+        return;
+    }
+    if (!font_storage_fetch_rows(chr, rows)) {
+        memset(rows, 0, 8u);
+    }
+}

--- a/firmware/eeprom_font_storage.h
+++ b/firmware/eeprom_font_storage.h
@@ -1,0 +1,18 @@
+#ifndef EEPROM_FONT_STORAGE_H
+#define EEPROM_FONT_STORAGE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define EEPROM_TOTAL_SIZE_BYTES 4096u
+#define EEPROM_PAGE_SIZE_BYTES 32u
+#define EEPROM_FONT_BASE 0x0200u
+#define EEPROM_FONT_LENGTH 0x800u
+
+bool eeprom_read_bytes(uint16_t offset, uint8_t *data, uint16_t length);
+bool eeprom_write_bytes(uint16_t offset, const uint8_t *data, uint16_t length);
+bool eeprom_wait_ready(uint32_t timeout_ms);
+bool font_storage_fetch_rows(uint8_t code, uint8_t *rows);
+void ssd1306_font_fetch(uint8_t chr, uint8_t *rows);
+
+#endif /* EEPROM_FONT_STORAGE_H */

--- a/firmware/eeprom_font_writer.c
+++ b/firmware/eeprom_font_writer.c
@@ -1,0 +1,129 @@
+#include "ch32fun.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "eeprom_font_storage.h"
+#include "i2c_lowlevel.h"
+
+#include "../ch32fun/extralibs/ssd1306_i2c.h"
+#include "../ch32fun/extralibs/font_8x8.h"
+
+#define FONT_WRITER_I2C_HZ 400000u
+
+static void init_i2c(void)
+{
+    funGpioInitAll();
+    ssd1306_i2c_init();
+    i2c1_configure_speed(FONT_WRITER_I2C_HZ);
+}
+
+static void bus_stop(void)
+{
+    I2C1->CTLR1 |= I2C_CTLR1_STOP;
+}
+
+static void clear_ack_failure(void)
+{
+    if (I2C1->STAR1 & I2C_STAR1_AF) {
+        I2C1->STAR1 &= (uint16_t)~I2C_STAR1_AF;
+    }
+}
+
+static bool i2c_device_present(uint8_t addr)
+{
+    if (!i2c1_wait_not_busy()) {
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_START;
+    if (!i2c1_wait_flag(0x00030001u)) {
+        bus_stop();
+        return false;
+    }
+
+    I2C1->DATAR = (uint16_t)((uint16_t)addr << 1);
+    if (!i2c1_wait_flag(0x00030002u)) {
+        clear_ack_failure();
+        bus_stop();
+        return false;
+    }
+
+    (void)I2C1->STAR1;
+    (void)I2C1->STAR2;
+    bus_stop();
+    return true;
+}
+
+static void scan_bus(void)
+{
+    printf("I2C scan start\r\n");
+    for (uint8_t addr = 0x08u; addr < 0x78u; ++addr) {
+        if (i2c_device_present(addr)) {
+            printf(" - found 0x%02X\r\n", addr);
+        }
+    }
+    printf("I2C scan done\r\n");
+}
+
+static bool verify_font(void)
+{
+    uint8_t buffer[EEPROM_PAGE_SIZE_BYTES];
+    const uint16_t font_len = (uint16_t)sizeof(fontdata);
+    for (uint16_t offset = 0; offset < font_len; offset += EEPROM_PAGE_SIZE_BYTES) {
+        uint16_t chunk = EEPROM_PAGE_SIZE_BYTES;
+        if ((uint32_t)offset + chunk > font_len) {
+            chunk = (uint16_t)(font_len - offset);
+        }
+        if (!eeprom_read_bytes((uint16_t)(EEPROM_FONT_BASE + offset), buffer, chunk)) {
+            return false;
+        }
+        if (memcmp(buffer, &fontdata[offset], chunk) != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+int main(void)
+{
+    SystemInit();
+    init_i2c();
+    scan_bus();
+
+    const uint16_t font_len = (uint16_t)sizeof(fontdata);
+    if (font_len != EEPROM_FONT_LENGTH) {
+        printf("font size mismatch (%u vs %u)\r\n", font_len, (unsigned)EEPROM_FONT_LENGTH);
+        while (1) {
+            Delay_Ms(1000);
+        }
+    }
+
+    if (!eeprom_wait_ready(50u)) {
+        printf("EEPROM not responding\r\n");
+        while (1) {
+            Delay_Ms(1000);
+        }
+    }
+
+    if (!eeprom_write_bytes(EEPROM_FONT_BASE, fontdata, font_len)) {
+        printf("EEPROM write failed\r\n");
+        while (1) {
+            Delay_Ms(1000);
+        }
+    }
+
+    if (!verify_font()) {
+        printf("EEPROM verify failed\r\n");
+        while (1) {
+            Delay_Ms(1000);
+        }
+    }
+
+    printf("EEPROM font programmed (%u bytes)\r\n", font_len);
+    while (1) {
+        Delay_Ms(1000);
+    }
+}

--- a/firmware/i2c_lowlevel.c
+++ b/firmware/i2c_lowlevel.c
@@ -1,0 +1,333 @@
+#include "i2c_lowlevel.h"
+
+#include "ch32fun.h"
+
+void i2c1_configure_speed(uint32_t target_hz)
+{
+    if (target_hz == 0u) {
+        return;
+    }
+
+    uint32_t pclk_hz = FUNCONF_SYSTEM_CORE_CLOCK;
+    if (pclk_hz == 0u) {
+        pclk_hz = 48000000u;
+    }
+
+    uint32_t freq_mhz = pclk_hz / 1000000u;
+    if (freq_mhz < 2u) {
+        freq_mhz = 2u;
+    }
+    if (freq_mhz > 32u) {
+        freq_mhz = 32u;
+    }
+
+    I2C1->CTLR1 &= ~I2C_CTLR1_PE;
+
+    I2C1->CTLR2 &= ~I2C_CTLR2_FREQ;
+    I2C1->CTLR2 |= (uint16_t)(freq_mhz & I2C_CTLR2_FREQ);
+
+    uint32_t fast_cutoff_hz = 100000u;
+    uint32_t ckcfgr = 0u;
+
+    if (target_hz <= fast_cutoff_hz) {
+        uint32_t denom = target_hz * 2u;
+        uint32_t ccr = (pclk_hz + denom - 1u) / denom;
+        if (ccr < 4u) {
+            ccr = 4u;
+        }
+        if (ccr > 0x0FFFu) {
+            ccr = 0x0FFFu;
+        }
+        ckcfgr = ccr & 0x0FFFu;
+    } else {
+        uint32_t denom = target_hz * 3u;
+        uint32_t ccr = (pclk_hz + denom - 1u) / denom;
+        if (ccr < 1u) {
+            ccr = 1u;
+        }
+        if (ccr > 0x0FFFu) {
+            ccr = 0x0FFFu;
+        }
+        ckcfgr = I2C_CKCFGR_FS | (ccr & 0x0FFFu);
+    }
+
+    I2C1->CKCFGR = (uint16_t)ckcfgr;
+
+    I2C1->CTLR1 |= I2C_CTLR1_PE;
+    I2C1->CTLR1 |= I2C_CTLR1_ACK;
+}
+
+bool i2c1_wait_flag(uint32_t mask)
+{
+    int32_t timeout = 100000;
+    while (timeout-- > 0) {
+        uint32_t status = I2C1->STAR1 | ((uint32_t)I2C1->STAR2 << 16);
+        if ((status & mask) == mask) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool i2c1_wait_not_busy(void)
+{
+    int32_t timeout = 100000;
+    while (timeout-- > 0) {
+        if ((I2C1->STAR2 & I2C_STAR2_BUSY) == 0u) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool i2c1_read_current_u8(uint8_t addr, uint8_t *value)
+{
+    if (!value) {
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_ACK;
+    I2C1->CTLR1 |= I2C_CTLR1_START;
+
+    if (!i2c1_wait_flag(0x00030001u)) {
+        return false;
+    }
+
+    I2C1->DATAR = (uint16_t)(((uint16_t)addr << 1) | 1u);
+
+    if (!i2c1_wait_flag(0x00030002u)) {
+        return false;
+    }
+
+    I2C1->CTLR1 &= ~I2C_CTLR1_ACK;
+    I2C1->CTLR1 |= I2C_CTLR1_STOP;
+
+    int32_t timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_RXNE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        return false;
+    }
+
+    *value = (uint8_t)I2C1->DATAR;
+    I2C1->CTLR1 |= I2C_CTLR1_ACK;
+    return true;
+}
+
+bool i2c1_write_u8(uint8_t addr, uint8_t reg, uint8_t data)
+{
+    if (!i2c1_wait_not_busy()) {
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_START;
+    if (!i2c1_wait_flag(0x00030001u)) {
+        return false;
+    }
+
+    I2C1->DATAR = (uint16_t)((uint16_t)addr << 1);
+    if (!i2c1_wait_flag(0x00070082u)) {
+        return false;
+    }
+
+    int32_t timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        return false;
+    }
+
+    I2C1->DATAR = reg;
+    if (!i2c1_wait_flag(0x00070084u)) {
+        return false;
+    }
+
+    timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        return false;
+    }
+
+    I2C1->DATAR = data;
+    if (!i2c1_wait_flag(0x00070084u)) {
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_STOP;
+    return true;
+}
+
+bool i2c1_write_u16(uint8_t addr, uint8_t reg, uint16_t value)
+{
+    if (!i2c1_wait_not_busy()) {
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_START;
+    if (!i2c1_wait_flag(0x00030001u)) {
+        return false;
+    }
+
+    I2C1->DATAR = (uint16_t)((uint16_t)addr << 1);
+    if (!i2c1_wait_flag(0x00070082u)) {
+        return false;
+    }
+
+    int32_t timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        return false;
+    }
+
+    I2C1->DATAR = reg;
+    if (!i2c1_wait_flag(0x00070084u)) {
+        return false;
+    }
+
+    timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        return false;
+    }
+
+    I2C1->DATAR = (uint8_t)(value >> 8);
+    if (!i2c1_wait_flag(0x00070084u)) {
+        return false;
+    }
+
+    timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        return false;
+    }
+
+    I2C1->DATAR = (uint8_t)(value & 0xFFu);
+    if (!i2c1_wait_flag(0x00070084u)) {
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_STOP;
+    return true;
+}
+
+bool i2c1_read_u16(uint8_t addr, uint8_t reg, uint16_t *value)
+{
+    if (!value) {
+        return false;
+    }
+
+    if (!i2c1_wait_not_busy()) {
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_START;
+    if (!i2c1_wait_flag(0x00030001u)) {
+        return false;
+    }
+
+    I2C1->DATAR = (uint16_t)((uint16_t)addr << 1);
+    if (!i2c1_wait_flag(0x00070082u)) {
+        return false;
+    }
+
+    int32_t timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        return false;
+    }
+
+    I2C1->DATAR = reg;
+    if (!i2c1_wait_flag(0x00070084u)) {
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_START;
+    if (!i2c1_wait_flag(0x00030001u)) {
+        return false;
+    }
+
+    I2C1->DATAR = (uint16_t)(((uint16_t)addr << 1) | 1u);
+    if (!i2c1_wait_flag(0x00030002u)) {
+        return false;
+    }
+
+    int32_t btf_timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_BTF) == 0u) && btf_timeout-- > 0) {
+    }
+    if (btf_timeout <= 0) {
+        return false;
+    }
+
+    I2C1->CTLR1 &= ~I2C_CTLR1_ACK;
+    I2C1->CTLR1 |= I2C_CTLR1_STOP;
+
+    uint8_t msb = (uint8_t)I2C1->DATAR;
+    uint8_t lsb = (uint8_t)I2C1->DATAR;
+
+    I2C1->CTLR1 |= I2C_CTLR1_ACK;
+
+    *value = ((uint16_t)msb << 8) | (uint16_t)lsb;
+    return true;
+}
+
+bool i2c1_read_u8(uint8_t addr, uint8_t reg, uint8_t *value)
+{
+    if (!value) {
+        return false;
+    }
+
+    if (!i2c1_wait_not_busy()) {
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_START;
+    if (!i2c1_wait_flag(0x00030001u)) {
+        return false;
+    }
+
+    I2C1->DATAR = (uint16_t)((uint16_t)addr << 1);
+    if (!i2c1_wait_flag(0x00070082u)) {
+        return false;
+    }
+
+    int32_t timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        return false;
+    }
+
+    I2C1->DATAR = reg;
+    if (!i2c1_wait_flag(0x00070084u)) {
+        return false;
+    }
+
+    I2C1->CTLR1 |= I2C_CTLR1_START;
+    if (!i2c1_wait_flag(0x00030001u)) {
+        return false;
+    }
+
+    I2C1->DATAR = (uint16_t)(((uint16_t)addr << 1) | 1u);
+    if (!i2c1_wait_flag(0x00030002u)) {
+        return false;
+    }
+
+    I2C1->CTLR1 &= ~I2C_CTLR1_ACK;
+    I2C1->CTLR1 |= I2C_CTLR1_STOP;
+
+    timeout = 100000;
+    while (((I2C1->STAR1 & I2C_STAR1_RXNE) == 0u) && timeout-- > 0) {
+    }
+    if (timeout <= 0) {
+        return false;
+    }
+
+    *value = (uint8_t)I2C1->DATAR;
+    I2C1->CTLR1 |= I2C_CTLR1_ACK;
+    return true;
+}

--- a/firmware/i2c_lowlevel.h
+++ b/firmware/i2c_lowlevel.h
@@ -1,0 +1,16 @@
+#ifndef I2C_LOWLEVEL_H
+#define I2C_LOWLEVEL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+void i2c1_configure_speed(uint32_t target_hz);
+bool i2c1_wait_flag(uint32_t mask);
+bool i2c1_wait_not_busy(void);
+bool i2c1_read_current_u8(uint8_t addr, uint8_t *value);
+bool i2c1_write_u8(uint8_t addr, uint8_t reg, uint8_t data);
+bool i2c1_write_u16(uint8_t addr, uint8_t reg, uint16_t value);
+bool i2c1_read_u16(uint8_t addr, uint8_t reg, uint16_t *value);
+bool i2c1_read_u8(uint8_t addr, uint8_t reg, uint8_t *value);
+
+#endif /* I2C_LOWLEVEL_H */

--- a/firmware/whisker_breeze.c
+++ b/firmware/whisker_breeze.c
@@ -5,6 +5,9 @@
 #include <string.h>
 #include <stdarg.h>
 
+#include "i2c_lowlevel.h"
+#include "eeprom_font_storage.h"
+
 typedef int32_t fix16_t;
 
 #define FIX16_FRAC_BITS 16
@@ -18,6 +21,7 @@ typedef int32_t fix16_t;
 #define SSD1306_OFFSET 30
 /* 严格对齐“起始地址偏移版”参考：纵向偏移 0x0C，列起点偏移列=28（低0x0C/高0x11） */
 #define SSD1306_VOFFSET 12
+#define SSD1306_USE_EXTERNAL_FONT 1u /* app-side only; submodule未依赖此宏 */
 
 /*
  * 逻辑坐标从 (0,0) 开始，实际写入时通过列偏移=30、行偏移=14 映射到玻璃。
@@ -44,6 +48,44 @@ static int ssd1306_quiet_printf(const char *fmt, ...)
 #include "../ch32fun/extralibs/ssd1306_i2c.h"
 #undef printf
 #include "../ch32fun/extralibs/ssd1306.h"
+
+/*
+ * 应用侧自定义字库渲染：不修改子模块，改为在本文件内提供
+ * ssd1306_drawstr 的等价实现，并通过宏将调用重定向到这里。
+ * 依赖 eeprom_font_storage.ssd1306_font_fetch() 从外置 EEPROM 取 8x8 字形。
+ */
+static inline void wb_drawchar_ext(uint8_t x, uint8_t y, uint8_t chr, uint8_t color)
+{
+    uint8_t rows[8];
+    ssd1306_font_fetch(chr, rows);
+    for (uint32_t i = 0; i < 8; ++i) {
+        uint8_t row = rows[i];
+        for (uint32_t j = 0; j < 8; ++j) {
+            /* 字形按bit7为最高位 -> 左到右 */
+            uint8_t bit = (uint8_t)(0x80u >> j);
+            if (row & bit) {
+                ssd1306_drawPixel((uint32_t)x + j, (uint32_t)y + i, color);
+            } else {
+                /* 背景保持不变：不清像素，避免闪烁；行级别先清屏 */
+            }
+        }
+    }
+}
+
+static inline void wb_drawstr_ext(uint8_t x, uint8_t y, char *str, uint8_t color)
+{
+    if (!str) return;
+    uint8_t cx = x;
+    for (const char *p = str; *p; ++p) {
+        /* 简单ASCII宽度8像素，超出宽度直接裁剪 */
+        if ((uint32_t)cx >= SSD1306_W) break;
+        wb_drawchar_ext(cx, y, (uint8_t)*p, color);
+        cx = (uint8_t)(cx + 8);
+    }
+}
+
+/* 将本文件后续对 ssd1306_drawstr 的调用全部重定向到应用侧实现 */
+#define ssd1306_drawstr wb_drawstr_ext
 
 /* Orientation: do software 180° rotation at flush time for correctness. */
 
@@ -696,297 +738,6 @@ static void log_fan_snapshot(void)
              (unsigned)bus_raw);
 }
 
-/* -------------------------------------------------------------------------- */
-/* Debounce helpers                                                           */
-/* -------------------------------------------------------------------------- */
-static bool debounce_update(debounce_t *db, bool raw_level)
-{
-    if (raw_level == db->stable_state) {
-        db->counter = 0;
-        return false;
-    }
-
-    if (db->counter < MODE_DEBOUNCE_TICKS) {
-        db->counter++;
-        if (db->counter >= MODE_DEBOUNCE_TICKS) {
-            db->stable_state = raw_level;
-            db->counter = 0;
-            return true;
-        }
-    }
-    return false;
-}
-
-/* -------------------------------------------------------------------------- */
-/* I2C helpers (blocking)                                                     */
-/* -------------------------------------------------------------------------- */
-static void i2c1_configure_speed(uint32_t target_hz)
-{
-    if (target_hz == 0u) {
-        return;
-    }
-
-    uint32_t pclk_hz = FUNCONF_SYSTEM_CORE_CLOCK;
-    if (pclk_hz == 0u) {
-        pclk_hz = 48000000u;
-    }
-
-    uint32_t freq_mhz = pclk_hz / 1000000u;
-    if (freq_mhz < 2u) {
-        freq_mhz = 2u;
-    }
-    if (freq_mhz > 32u) {
-        freq_mhz = 32u;
-    }
-
-    I2C1->CTLR1 &= ~I2C_CTLR1_PE;
-
-    I2C1->CTLR2 &= ~I2C_CTLR2_FREQ;
-    I2C1->CTLR2 |= (uint16_t)(freq_mhz & I2C_CTLR2_FREQ);
-
-    uint32_t fast_cutoff_hz = 100000u;
-    uint32_t ckcfgr = 0u;
-
-    if (target_hz <= fast_cutoff_hz) {
-        uint32_t denom = target_hz * 2u;
-        uint32_t ccr = (pclk_hz + denom - 1u) / denom;
-        if (ccr < 4u) {
-            ccr = 4u;
-        }
-        if (ccr > 0x0FFFu) {
-            ccr = 0x0FFFu;
-        }
-        ckcfgr = ccr & 0x0FFFu;
-    } else {
-        uint32_t denom = target_hz * 3u;
-        uint32_t ccr = (pclk_hz + denom - 1u) / denom;
-        if (ccr < 1u) {
-            ccr = 1u;
-        }
-        if (ccr > 0x0FFFu) {
-            ccr = 0x0FFFu;
-        }
-        ckcfgr = I2C_CKCFGR_FS | (ccr & 0x0FFFu);
-    }
-
-    I2C1->CKCFGR = (uint16_t)ckcfgr;
-
-    I2C1->CTLR1 |= I2C_CTLR1_PE;
-    I2C1->CTLR1 |= I2C_CTLR1_ACK;
-}
-
-static bool i2c1_wait_flag(uint32_t mask)
-{
-    int32_t timeout = 100000;
-    while (timeout-- > 0) {
-        uint32_t status = I2C1->STAR1 | ((uint32_t)I2C1->STAR2 << 16);
-        if ((status & mask) == mask) {
-            return true;
-        }
-    }
-    return false;
-}
-
-static bool i2c1_wait_not_busy(void)
-{
-    int32_t timeout = 100000;
-    while (timeout-- > 0) {
-        if ((I2C1->STAR2 & I2C_STAR2_BUSY) == 0u) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/* i2c1_scan_bus removed: address discovery not required */
-
-static bool i2c1_read_current_u8(uint8_t addr, uint8_t *value)
-{
-    if (!value) {
-        return false;
-    }
-
-    I2C1->CTLR1 |= I2C_CTLR1_ACK;
-    I2C1->CTLR1 |= I2C_CTLR1_START;
-
-    if (!i2c1_wait_flag(0x00030001u)) {
-        return false;
-    }
-
-    I2C1->DATAR = (uint16_t)(((uint16_t)addr << 1) | 1u);
-
-    if (!i2c1_wait_flag(0x00030002u)) {
-        return false;
-    }
-
-    I2C1->CTLR1 &= ~I2C_CTLR1_ACK;
-    I2C1->CTLR1 |= I2C_CTLR1_STOP;
-
-    int32_t timeout = 100000;
-    while (((I2C1->STAR1 & I2C_STAR1_RXNE) == 0u) && timeout-- > 0) {
-    }
-    if (timeout <= 0) {
-        return false;
-    }
-
-    *value = (uint8_t)I2C1->DATAR;
-    I2C1->CTLR1 |= I2C_CTLR1_ACK;
-    return true;
-}
-
-static bool i2c1_write_u8(uint8_t addr, uint8_t reg, uint8_t data)
-{
-    if (!i2c1_wait_not_busy()) {
-        return false;
-    }
-
-    I2C1->CTLR1 |= I2C_CTLR1_START;
-    if (!i2c1_wait_flag(0x00030001u)) {
-        return false;
-    }
-
-    I2C1->DATAR = (uint16_t)((uint16_t)addr << 1);
-    if (!i2c1_wait_flag(0x00070082u)) {
-        return false;
-    }
-
-    int32_t timeout = 100000;
-    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
-    }
-    if (timeout <= 0) {
-        return false;
-    }
-
-    I2C1->DATAR = reg;
-
-    timeout = 100000;
-    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
-    }
-    if (timeout <= 0) {
-        return false;
-    }
-
-    I2C1->DATAR = data;
-
-    if (!i2c1_wait_flag(0x00070084u)) {
-        return false;
-    }
-
-    I2C1->CTLR1 |= I2C_CTLR1_STOP;
-    return true;
-}
-
-static bool i2c1_write_u16(uint8_t addr, uint8_t reg, uint16_t value)
-{
-    if (!i2c1_wait_not_busy()) {
-        return false;
-    }
-
-    I2C1->CTLR1 |= I2C_CTLR1_START;
-    if (!i2c1_wait_flag(0x00030001u)) {
-        return false;
-    }
-
-    I2C1->DATAR = (uint16_t)((uint16_t)addr << 1);
-    if (!i2c1_wait_flag(0x00070082u)) {
-        return false;
-    }
-
-    int32_t timeout = 100000;
-    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
-    }
-    if (timeout <= 0) {
-        return false;
-    }
-
-    I2C1->DATAR = reg;
-
-    timeout = 100000;
-    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
-    }
-    if (timeout <= 0) {
-        return false;
-    }
-
-    I2C1->DATAR = (uint8_t)(value >> 8);
-
-    timeout = 100000;
-    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
-    }
-    if (timeout <= 0) {
-        return false;
-    }
-
-    I2C1->DATAR = (uint8_t)(value & 0xFFu);
-
-    if (!i2c1_wait_flag(0x00070084u)) {
-        return false;
-    }
-
-    I2C1->CTLR1 |= I2C_CTLR1_STOP;
-    return true;
-}
-
-static bool i2c1_read_u16(uint8_t addr, uint8_t reg, uint16_t *value)
-{
-    if (!value) {
-        return false;
-    }
-
-    if (!i2c1_wait_not_busy()) {
-        return false;
-    }
-
-    I2C1->CTLR1 |= I2C_CTLR1_START;
-    if (!i2c1_wait_flag(0x00030001u)) {
-        return false;
-    }
-
-    I2C1->DATAR = (uint16_t)((uint16_t)addr << 1);
-    if (!i2c1_wait_flag(0x00070082u)) {
-        return false;
-    }
-
-    int32_t timeout = 100000;
-    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
-    }
-    if (timeout <= 0) {
-        return false;
-    }
-
-    I2C1->DATAR = reg;
-    if (!i2c1_wait_flag(0x00070084u)) {
-        return false;
-    }
-
-    I2C1->CTLR1 |= I2C_CTLR1_START;
-    if (!i2c1_wait_flag(0x00030001u)) {
-        return false;
-    }
-
-    I2C1->DATAR = (uint16_t)(((uint16_t)addr << 1) | 1u);
-    if (!i2c1_wait_flag(0x00030002u)) {
-        return false;
-    }
-
-    int32_t btf_timeout = 100000;
-    while (((I2C1->STAR1 & I2C_STAR1_BTF) == 0u) && btf_timeout-- > 0) {
-    }
-    if (btf_timeout <= 0) {
-        return false;
-    }
-
-    I2C1->CTLR1 &= ~I2C_CTLR1_ACK;
-    I2C1->CTLR1 |= I2C_CTLR1_STOP;
-
-    uint8_t msb = (uint8_t)I2C1->DATAR;
-    uint8_t lsb = (uint8_t)I2C1->DATAR;
-
-    I2C1->CTLR1 |= I2C_CTLR1_ACK;
-
-    *value = ((uint16_t)msb << 8) | (uint16_t)lsb;
-    return true;
-}
 
 static uint16_t ina226_compute_calibration(void)
 {
@@ -1165,39 +916,26 @@ static void ina226_update(uint32_t delta_ms)
     }
 }
 
-static bool i2c1_read_u8(uint8_t addr, uint8_t reg, uint8_t *value)
+
+/* -------------------------------------------------------------------------- */
+/* Debounce helpers                                                           */
+/* -------------------------------------------------------------------------- */
+static bool debounce_update(debounce_t *db, bool raw_level)
 {
-    if (!value) {
+    if (raw_level == db->stable_state) {
+        db->counter = 0;
         return false;
     }
 
-    if (!i2c1_wait_not_busy()) {
-        return false;
+    if (db->counter < MODE_DEBOUNCE_TICKS) {
+        db->counter++;
+        if (db->counter >= MODE_DEBOUNCE_TICKS) {
+            db->stable_state = raw_level;
+            db->counter = 0;
+            return true;
+        }
     }
-
-    I2C1->CTLR1 |= I2C_CTLR1_START;
-    if (!i2c1_wait_flag(0x00030001u)) {
-        return false;
-    }
-
-    I2C1->DATAR = (uint16_t)((uint16_t)addr << 1);
-    if (!i2c1_wait_flag(0x00070082u)) {
-        return false;
-    }
-
-    int32_t timeout = 100000;
-    while (((I2C1->STAR1 & I2C_STAR1_TXE) == 0u) && timeout-- > 0) {
-    }
-    if (timeout <= 0) {
-        return false;
-    }
-
-    I2C1->DATAR = reg;
-    if (!i2c1_wait_flag(0x00070084u)) {
-        return false;
-    }
-
-    return i2c1_read_current_u8(addr, value);
+    return false;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -2397,6 +2135,20 @@ int main(void)
     temp_init();
     ssd1306_i2c_setup();
     i2c1_configure_speed(I2C1_SHARED_BUS_TARGET_HZ);
+
+    bool font_ready = eeprom_wait_ready(50u);
+    if (font_ready) {
+        uint8_t probe_rows[8];
+        if (!font_storage_fetch_rows('0', probe_rows)) {
+            emit_log("[ee] font missing");
+            font_ready = false;
+        }
+    } else {
+        emit_log("[ee] no ack");
+    }
+    if (!font_ready) {
+        g_display_error_seen = true;
+    }
 
     (void)WaitForDebuggerToAttach(13);
 


### PR DESCRIPTION
Summary
- Move SSD1306 glyph source from flash-linked table to external EEPROM (2 KB region at 0x0200–0x09FF).
- Add reusable low-level I2C helpers and EEPROM font storage module.
- Provide a one-shot provisioning firmware `eeprom_font_writer` to program/verify the font payload.
- Update build system with multi-target flow and convenience targets; refresh docs accordingly.
- Update ch32fun submodule pointer to a reachable upstream commit (no local changes to submodule content).

Details
- OLED rendering now fetches 8×8 ASCII glyph rows via `ssd1306_font_fetch()` from EEPROM at runtime. To avoid touching `ch32fun`, the application implements a local `ssd1306_drawstr`/`drawchar` wrapper that calls `ssd1306_drawPixel()` per bit. The submodule remains unmodified.
- New modules:
  - `firmware/i2c_lowlevel.{c,h}` — I2C1 timing/flag helpers, 8/16-bit register R/W, shared bus speed restore (default 400 kHz).
  - `firmware/eeprom_font_storage.{c,h}` — paged read/write, ready polling, and `ssd1306_font_fetch()` backed by EEPROM.
  - `firmware/eeprom_font_writer.c` — standalone app that scans I2C, writes the 2 KB font blob at 0x0200, and verifies by page.
- Build:
  - `firmware/Makefile` supports `TARGETS := whisker_breeze eeprom_font_writer` with `flash-*` helpers.
  - Top-level `Makefile`: `make flash` (main firmware) and `make flash-font` (provision writer, then reflash main as needed).
- Docs: README and `docs/design.md` note the EEPROM layout and provisioning flow.

Impact
- Code size: ~14.6 KB flash usage on CH32V003 (fits within 16 KB), RAM well under 2 KB.
- Behavior: Main firmware renders strings identically; font table is no longer linked into flash, freeing ~2 KB.
- Deployment: After assembling or replacing EEPROM, run `make flash-font` once to program/verify the font, then flash main.

Verification
- Hardware: CH32V003 @ shared I2C 400 kHz, SSD1306 72x40 custom window; OLED shows five lines (Set/Out/RPM/Mode/Voltage-Current) cleanly.
- Provisioning: `eeprom_font_writer` reports successful verify; subsequent main firmware renders correctly.
- I2C: On init, `ssd1306_i2c_init()` then `i2c1_configure_speed()` restores shared-bus speed; no continuous I2C errors observed.

Risks & Notes
- If EEPROM is blank or corrupted, text will appear empty. Re-run `make flash-font` to re-provision.
- No changes were made inside `ch32fun`; only the submodule pointer was updated to `ab05c94`. Please confirm this pointer is acceptable.

Files (high level)
- Modified: `Makefile`, `README.md`, `docs/design.md`, `firmware/Makefile`, `firmware/whisker_breeze.c`
- Added: `firmware/i2c_lowlevel.{c,h}`, `firmware/eeprom_font_storage.{c,h}`, `firmware/eeprom_font_writer.c`
- Submodule pointer: `ch32fun` → `ab05c94`

Checklist
- [x] Builds locally: `make flash` succeeds
- [x] Provisioning path works: `make flash-font`
- [x] Docs updated
- [x] No submodule source edits (pointer only)